### PR TITLE
Allow drafts to be set as "public"/"unlisted" and played by others

### DIFF
--- a/Server/Source/Routes/Downloads.ts
+++ b/Server/Source/Routes/Downloads.ts
@@ -21,7 +21,7 @@ async (req, res) => {
     const IsPreview = SongData.ID != SongData.PID && req.params.InternalID == SongData.PID;
     const ManifestPath = `${SongData.Directory}/${IsPreview ? `PreviewManifest.mpd` : `Manifest.mpd`}`;
     
-    if (SongData.IsDraft && (req.user!.PermissionLevel! < UserPermissions.VerifiedUser && SongData.Author.ID !== req.user!.ID))
+    if (SongData.IsDraft && !SongData.IsPublicDraft && (req.user!.PermissionLevel! < UserPermissions.VerifiedUser && SongData.Author.ID !== req.user!.ID))
         return res.status(403).send("You cannot use this track, because it's a draft.");
 
     const BaseURL = `${FULL_SERVER_ROOT}/song/download/${SongData.ID}/`;
@@ -85,7 +85,7 @@ async (req, res, next) => {
 
     const IsPreview = SongData.ID != SongData.PID && req.params.InternalID == SongData.PID;
 
-    if (SongData.IsDraft && ((req.user ? req.user.PermissionLevel < UserPermissions.VerifiedUser : true) && SongData.Author.ID !== req.user!.ID))
+    if (SongData.IsDraft && !SongData.IsPublicDraft && ((req.user ? req.user.PermissionLevel < UserPermissions.VerifiedUser : true) && SongData.Author.ID !== req.user!.ID))
         return res.status(403).send("You cannot use this track, because it's a draft.");
 
     const BaseURL = `${FULL_SERVER_ROOT}/song/download/${IsPreview ? SongData.PID : SongData.ID}/`;

--- a/Server/Source/Routes/Drafting.ts
+++ b/Server/Source/Routes/Drafting.ts
@@ -54,6 +54,7 @@ App.post("/create",
         const SongData = await Song.create({
             ...req.body,
             IsDraft: true,
+            IsPublicDraft: false,
             Status: SongStatus.PROCESSING,
             Author: req.user!
         }).save();
@@ -88,6 +89,7 @@ App.post("/upload/midi",
             rmSync(`${SAVED_DATA_PATH}/Songs/${req.body.TargetSong}/Data.mid`);
             SongData.HasMidi = false;
             SongData.IsDraft = true;
+            SongData.IsPublicDraft = false;
             await SongData.save();
         }
 
@@ -127,6 +129,7 @@ App.post("/upload/cover",
             rmSync(`${SAVED_DATA_PATH}/Songs/${req.body.TargetSong}/Cover.png`);
             SongData.HasCover = false;
             SongData.IsDraft = true;
+            SongData.IsPublicDraft = false;
             await SongData.save();
         }
 
@@ -192,6 +195,7 @@ App.post("/upload/audio",
             rmSync(ChunksPath, { recursive: true });
             SongData.HasAudio = false;
             SongData.IsDraft = true;
+            SongData.IsPublicDraft = false;
             SongData.Status = SongStatus.PROCESSING;
             await SongData.save();
         }
@@ -347,6 +351,7 @@ App.post("/submit",
         if (SongData.Status === SongStatus.ACCEPTED) {
             SongData.Status = SongStatus.PUBLIC;
             SongData.IsDraft = false;
+            SongData.IsPublicDraft = false;
             await SongData.save();
 
             return res.send("Song has been published successfully.");
@@ -360,6 +365,33 @@ App.post("/submit",
         await SongData.save();
 
         return res.send("Song has been submitted for approval by admins.");
+    });
+
+App.post("/makePublic",
+    RequireAuthentication(),
+    ValidateBody(j.object({
+        TargetSong: j.string().uuid().required()
+    })),
+    async (req, res) => {
+        const SongData = await Song.findOne({ where: { ID: req.body.TargetSong }, relations: { Author: true } })
+        if (!SongData)
+            return res.status(404).send("The draft you're trying change visibility does not exist.");
+
+        if (SongData.Author.ID !== req.user!.ID)
+            return res.status(403).send("You don't have permission change this draft's visibility.");
+
+        if (!SongData.IsDraft)
+            return res.status(400).send("This song has already been approved and published.");
+
+        var word = SongData.IsPublicDraft ? "private" : "public";
+
+        if (SongData.Status !== SongStatus.DEFAULT && SongData.Status !== SongStatus.AWAITING_REVIEW)
+            return res.status(400).send("You cannot make this draft " + word + " at this time.");
+
+        SongData.IsPublicDraft = !SongData.IsPublicDraft;
+        await SongData.save();
+
+        return res.send("Draft has been made " + word + ".");
     });
 
 export default {

--- a/Server/Source/Routes/Library.ts
+++ b/Server/Source/Routes/Library.ts
@@ -55,7 +55,7 @@ async (req, res) => {
     if (!SongData)
         return res.status(404).send("Provided song doesn't exist.");
 
-    if (SongData.IsDraft && (req.user!.PermissionLevel < UserPermissions.TrackVerifier && SongData.Author.ID !== req.user!.ID))
+    if (SongData.IsDraft && !SongData.IsPublicDraft && (req.user!.PermissionLevel < UserPermissions.TrackVerifier && SongData.Author.ID !== req.user!.ID))
         return res.status(403).send("You cannot activate this track, because it's a draft.");
 
     req.user!.Library.push({ SongID: req.body.SongID.toLowerCase(), Overriding: req.body.ToOverride.toLowerCase() });
@@ -93,7 +93,7 @@ async (req, res) => {
     if (!SongData)
         return res.status(404).send("Provided song doesn't exist.");
 
-    if (SongData.IsDraft && (req.user.PermissionLevel < UserPermissions.TrackVerifier && SongData.Author.ID !== req.user.ID))
+    if (SongData.IsDraft && !SongData.IsPublicDraft && (req.user.PermissionLevel < UserPermissions.TrackVerifier && SongData.Author.ID !== req.user.ID))
         return res.status(403).send("You cannot subscribe to this track, because it's a draft.");
 
     req.user?.BookmarkedSongs.push(SongData);
@@ -125,7 +125,7 @@ async (req, res) => {
     if (!SongData)
         return res.status(404).send("Provided song doesn't exist.");
 
-    if (SongData.IsDraft && (req.user!.PermissionLevel < UserPermissions.TrackVerifier && SongData.Author.ID !== req.user!.ID))
+    if (SongData.IsDraft && !SongData.IsPublicDraft && (req.user!.PermissionLevel < UserPermissions.TrackVerifier && SongData.Author.ID !== req.user!.ID))
         return res.status(403).send("You cannot use assets of this track, because it's a draft.");
 
     res.json(SongData.Package());

--- a/Server/Source/Schemas/Song.ts
+++ b/Server/Source/Schemas/Song.ts
@@ -78,6 +78,9 @@ export class Song extends BaseEntity {
     @Column()
     IsDraft: boolean;
 
+    @Column()
+    IsPublicDraft: boolean;
+
     @Column({ default: false })
     HasMidi: boolean;
 

--- a/Server/Source/Schemas/Song.ts
+++ b/Server/Source/Schemas/Song.ts
@@ -78,7 +78,7 @@ export class Song extends BaseEntity {
     @Column()
     IsDraft: boolean;
 
-    @Column()
+    @Column({ default: false })
     IsPublicDraft: boolean;
 
     @Column({ default: false })

--- a/src/components/Song.tsx
+++ b/src/components/Song.tsx
@@ -20,7 +20,9 @@ export function Song({ data, children }: { data: any, children?: JSX.Element[] |
             case SongStatus.DEFAULT:
                 // no label unless draft
                 Variant = "danger";
-                if (data.IsDraft)
+                if (data.IsPublicDraft)
+                    LabelStr = "Draft - public"
+                else if (data.IsDraft)
                     LabelStr = "Draft - not published"
                 break;
             case SongStatus.PUBLIC:

--- a/src/components/Song.tsx
+++ b/src/components/Song.tsx
@@ -1,8 +1,10 @@
-import { Box, Label, Text } from "@primer/react";
+import { Box, Label, Text, Link } from "@primer/react";
 import { Divider } from "@primer/react/lib-esm/ActionList/Divider";
 import { SongStatus } from "../utils/Extensions";
 import { LabelColorOptions } from "@primer/react/lib-esm/Label/Label";
+import { LinkIcon } from "@primer/octicons-react"
 import DefaultCover from "../assets/NoCoverDetected.png";
+import { toast } from "react-toastify";
 
 export function Song({ data, children }: { data: any, children?: JSX.Element[] | JSX.Element | string }) {
     function GetStatusLabel() {
@@ -51,6 +53,17 @@ export function Song({ data, children }: { data: any, children?: JSX.Element[] |
         )
     }
 
+    function GetLinkIcon() {
+        if (data.Status == SongStatus.PUBLIC || data.IsPublicDraft)
+        {
+            return <Link sx={{ cursor: "pointer", marginLeft: 1 }} onClick={() => {
+                navigator.clipboard.writeText(window.location.origin + "/song/" + data.ID);
+                toast("Copied song link to clipboard",{type:"success"})
+            }}><LinkIcon /></Link>
+        }
+        return <></>
+    }
+
     return (
         <Box sx={{ overflow: "hidden", minWidth: 50, maxWidth: 200, padding: 2, borderRadius: 10, border: "solid", borderColor: "border.default" }}>
             <img onError={e => (e.target as HTMLImageElement).src = DefaultCover} src={data.Cover} style={{ width: "100%", borderRadius: 10 }} />
@@ -59,6 +72,9 @@ export function Song({ data, children }: { data: any, children?: JSX.Element[] |
                 <Text sx={{ display: "block", textOverflow: "ellipsis", overflow: "hidden", whiteSpace: "nowrap" }}><b>{data.Name}</b></Text>
                 {
                     GetStatusLabel()
+                }
+                {
+                    GetLinkIcon()
                 }
                 {
                     children ? <Divider /> : <></>

--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -259,6 +259,16 @@ export function Profile() {
 												
 												toast(Res.data, { type: Res.status === 200 ? "success" : "error" });
 											}}>{x.Status === SongStatus.DEFAULT ? "Submit for Review" : "Publish"}</Button>
+											<Button disabled={x.Status !== SongStatus.DEFAULT && x.Status !== SongStatus.AWAITING_REVIEW} sx={{ width: "100%", marginBottom: 1 }} onClick={async () => {
+												const Res = await axios.post("/api/drafts/makePublic", { TargetSong: x.ID });
+												if (Res.status === 200) {
+													x.IsPublicDraft = !x.IsPublicDraft;
+													draftsSongs[i] = x;
+													setDraftsSongs([...draftsSongs]);
+												}
+												
+												toast(Res.data, { type: Res.status === 200 ? "success" : "error" });
+											}}>{!x.IsPublicDraft ? "Make draft Public" : "Make draft Private"}</Button>
 											<Button disabled={!state.UserDetails.IsAdmin && x.Status !== SongStatus.DEFAULT && x.Status !== SongStatus.DENIED && x.Status !== SongStatus.BROKEN} sx={{ width: "100%" }} variant="danger" onClick={async () => {
 												const Res = await axios.post("/api/drafts/delete", { TargetSong: x.ID });
 												if (Res.status === 200) {


### PR DESCRIPTION
The main idea is for the average chart creator to gather feedback on WIP charts, or charts they otherwise know won't be approved (i.e. overcharts), without having them be manually verified.

WIP - Pending:
- actual song page (waiting on feature by main dev team)
- maybe change wording from "public" to "unlisted"?
- more thorough testing, especially ingame